### PR TITLE
Use new OpsCenter and Agent 5.2.4 image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,24 @@
-TAG ?= "meder/cassandra_cluster:latest"
+C_TAG ?= "meder/cassandra_cluster:latest"
+OC_TAG ?= "meder/cassandra_opscenter:latest"
 DOCKER ?= docker
 
 .DEFAULT_GOAL: run
-run:
-	@sh ./scripts/cassandraDockerCluster.sh
 
-build:
-	@$(DOCKER) build -t $(TAG) --rm=true .
-	@$(DOCKER) pull abh1nav/opscenter:latest
+all: clean build run
+
+run:
+	@sh ./cassandraDockerCluster.sh
+
+build: cluster opscenter
+
+cluster:
+	@$(DOCKER) build -t $(C_TAG) --rm=true cluster/.
+
+opscenter:
+	@$(DOCKER) build -t $(OC_TAG) --rm=true opscenter/.
 
 clean:
-	@$(DOCKER) ps -a -q --filter ancestor=$(TAG) --format="{{.ID}}" | xargs $(DOCKER) stop | xargs $(DOCKER) rm
-	@$(DOCKER) ps -a -q --filter ancestor=abh1nav/opscenter --format="{{.ID}}" | xargs $(DOCKER) stop | xargs $(DOCKER) rm
+	@$(DOCKER) ps -a -q --filter ancestor=$(C_TAG) --format="{{.ID}}" | xargs $(DOCKER) stop | xargs $(DOCKER) rm
+	@$(DOCKER) ps -a -q --filter ancestor=$(OC_TAG) --format="{{.ID}}" | xargs $(DOCKER) stop | xargs $(DOCKER) rm
 
-.PHONY: clean run
+.PHONY: all cluster opscenter build clean run

--- a/cluster/Dockerfile
+++ b/cluster/Dockerfile
@@ -1,8 +1,10 @@
 # vim:set ft=dockerfile:
 FROM spotify/cassandra:cluster
+MAINTAINER Nils Meder <nilstgmd@gmx.de>
 
 RUN mkdir /opt/agent \
-    && wget -O - http://downloads.datastax.com/community/datastax-agent-5.1.0.tar.gz | tar xzf - --strip-components=1 -C "/opt/agent"
+    && wget -O - http://downloads.datastax.com/community/datastax-agent-5.2.4.tar.gz \
+    | tar xzf - --strip-components=1 -C "/opt/agent"
 
 COPY scripts/entrypoint.sh /sbin/entrypoint.sh
 RUN chmod 755 /sbin/entrypoint.sh

--- a/cluster/scripts/entrypoint.sh
+++ b/cluster/scripts/entrypoint.sh
@@ -13,6 +13,6 @@ else
 
 	echo "Sleeping 10 sec. before starting agent"
 	sleep 10
-	nohup sh /opt/agent/bin/datastax-agent &
+	nohup bash /opt/agent/bin/datastax-agent &
 fi
 sh /usr/local/bin/cassandra-clusternode

--- a/opscenter/Dockerfile
+++ b/opscenter/Dockerfile
@@ -1,0 +1,17 @@
+# vim:set ft=dockerfile:
+FROM python:2.7.11
+MAINTAINER Nils Meder <nilstgmd@gmx.de>
+
+# Download and extract OpsCenter
+RUN \
+  mkdir -p /opt/opscenter; \
+  wget -O - http://downloads.datastax.com/community/opscenter-5.2.4.tar.gz \
+  | tar xzf - --strip-components=1 -C "/opt/opscenter";
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Expose ports
+EXPOSE 8888
+
+WORKDIR /opt/opscenter
+
+CMD ["bin/opscenter", "-f"]


### PR DESCRIPTION
This pull request splits up Dockerfiles for C\* and OpsCenter. This is necessary to update the version of the DataStax Agent and OpsCenter to `5.2.4`.
